### PR TITLE
Pinning covalent-aws-plugins to 0.1.0rc0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Introduced `AWSExecutor` as a second parent to the `EC2Executor`
+- Updated requirements.txt to pin aws executor plugins to pre-release version 0.1.0rc0
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Introduced `AWSExecutor` as a second parent to the `EC2Executor`
 - Updated requirements.txt to pin aws executor plugins to pre-release version 0.1.0rc0
+- Updated requirements.txt to pin ssh plugin to version 0.13.0rc0
 
 ### Tests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/AgnostiqHQ/covalent-aws-plugins.git@develop#egg=covalent-aws-plugins
+covalent-aws-plugins==0.1.0rc0
 git+https://github.com/AgnostiqHQ/covalent-ssh-plugin.git@develop#egg=covalent-ssh-plugin

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 covalent-aws-plugins==0.1.0rc0
-git+https://github.com/AgnostiqHQ/covalent-ssh-plugin.git@develop#egg=covalent-ssh-plugin
+covalent-ssh-plugin==0.13.0rc0


### PR DESCRIPTION
Pinning covalent-aws-plugins to 0.1.0rc0

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.
